### PR TITLE
Housekeeping: Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ __pycache__/
 # C extensions
 *.so
 
+# macOS
+.DS_Store
+**/.DS_Store
+
 # Distribution / packaging
 .Python
 build/


### PR DESCRIPTION
Prevent macOS .DS_Store files from showing up in git status.